### PR TITLE
feat(MsgBox): decode execute-msg

### DIFF
--- a/src/components/MsgBox.tsx
+++ b/src/components/MsgBox.tsx
@@ -7,6 +7,7 @@ import {
   isValidatorAddress
 } from "../scripts/utility";
 import format from "../scripts/format";
+import { decodeBase64 } from "../scripts/utility";
 import Finder from "./Finder";
 import { isArray } from "lodash";
 
@@ -52,6 +53,13 @@ export default ({ msg }: { msg: Msg }) => {
             <p key={index}>
               <span>{key}</span>
               <span>{format.denom(msg.value[key])}</span>
+            </p>
+          );
+        } else if (key === "execute_msg") {
+          return (
+            <p key={index}>
+              <span>{key}</span>
+              <span>{decodeBase64(msg.value[key])}</span>
             </p>
           );
         } else {

--- a/src/scripts/utility.ts
+++ b/src/scripts/utility.ts
@@ -66,3 +66,7 @@ export function prependProtocol(url: string) {
     return `http://` + url;
   }
 }
+
+export function decodeBase64(key: string) {
+  return Buffer.from(key, "base64").toString();
+}

--- a/src/scripts/utility.ts
+++ b/src/scripts/utility.ts
@@ -67,6 +67,10 @@ export function prependProtocol(url: string) {
   }
 }
 
-export function decodeBase64(key: string) {
-  return Buffer.from(key, "base64").toString();
+export function decodeBase64(str: string) {
+  try {
+    return Buffer.from(str, "base64").toString();
+  } catch {
+    return str;
+  }
 }


### PR DESCRIPTION
component/MsgBox.tsx에 key값이 execute_msg일때 value를 디코드되도록 변경하였습니다
execute_msg가 base64로 finder에서 인코드되어있는 값을 디코드하여 사용자가 읽을 수 있게끔 하였습니다.
https://finder.terra.money/tequila-0004/tx/BAE8A42B663B35001265228D58E9E2316D0C75356FC4E7B085AA5CE069007F4D