### PR TITLE
fix: prettify wasm

### DIFF
--- a/src/components/WasmMsg.tsx
+++ b/src/components/WasmMsg.tsx
@@ -15,7 +15,7 @@ const prettifyWasmMsg = (str: string | object) => {
   if (typeof str === "string" && isBase64Extended(str)) {
     const decoded = decodeBase64(str);
     try {
-      return JSON.stringify(JSON.parse(decoded.toString(), reviver), null, 2);
+      return JSON.stringify(JSON.parse(decoded, reviver), null, 2);
     } catch (_) {
       return decoded;
     }

--- a/src/components/WasmMsg.tsx
+++ b/src/components/WasmMsg.tsx
@@ -1,16 +1,22 @@
 import isBase64 from "is-base64";
 import { decodeBase64 } from "../scripts/utility";
 
+const isBase64Extended = (value: string) =>
+  typeof value === "string" && !value.startsWith("terra1") && isBase64(value);
+
 function reviver(_: string, value: any) {
-  return isBase64(value) ? JSON.parse(decodeBase64(value), reviver) : value;
+  return isBase64Extended(value)
+    ? JSON.parse(decodeBase64(value), reviver)
+    : value;
 }
 
 const prettifyWasmMsg = (str: string | object) => {
-  if (typeof str === "string" && isBase64(str)) {
+  if (typeof str === "string" && isBase64Extended(str)) {
     const decoded = decodeBase64(str);
     try {
       return JSON.stringify(JSON.parse(decoded.toString(), reviver), null, 2);
     } catch (_) {
+      console.log(_);
       return decoded;
     }
   }

--- a/src/components/WasmMsg.tsx
+++ b/src/components/WasmMsg.tsx
@@ -3,7 +3,13 @@ import { decodeBase64 } from "../scripts/utility";
 
 // is-base64 takes terra1 address as base64 as well; prevent this.
 const isBase64Extended = (value: string) =>
-  typeof value === "string" && !value.startsWith("terra1") && isBase64(value);
+  typeof value === "string" &&
+  // case: terra1... address is bech32 and it naturally is base64-eligible.
+  !value.startsWith("terra1") &&
+  // case: we are only interested in json-alike base64's, which generally start with "ey" ('{')
+  value.startsWith("ey") &&
+  // other checks
+  isBase64(value);
 
 const reviver = (_: string, value: any) =>
   isBase64Extended(value) ? JSON.parse(decodeBase64(value), reviver) : value;

--- a/src/components/WasmMsg.tsx
+++ b/src/components/WasmMsg.tsx
@@ -5,11 +5,8 @@ import { decodeBase64 } from "../scripts/utility";
 const isBase64Extended = (value: string) =>
   typeof value === "string" && !value.startsWith("terra1") && isBase64(value);
 
-function reviver(_: string, value: any) {
-  return isBase64Extended(value)
-    ? JSON.parse(decodeBase64(value), reviver)
-    : value;
-}
+const reviver = (_: string, value: any) =>
+  isBase64Extended(value) ? JSON.parse(decodeBase64(value), reviver) : value;
 
 const prettifyWasmMsg = (str: string | object) => {
   if (typeof str === "string" && isBase64Extended(str)) {

--- a/src/components/WasmMsg.tsx
+++ b/src/components/WasmMsg.tsx
@@ -1,19 +1,17 @@
 import isBase64 from "is-base64";
 import { decodeBase64 } from "../scripts/utility";
 
+function reviver(_: string, value: any) {
+  return isBase64(value) ? JSON.parse(decodeBase64(value), reviver) : value;
+}
+
 const prettifyWasmMsg = (str: string | object) => {
   if (typeof str === "string" && isBase64(str)) {
     const decoded = decodeBase64(str);
     try {
-      const parsed = JSON.parse(decoded);
-      if (typeof parsed === "object") {
-        Object.keys(parsed).forEach(key => {
-          parsed[key].msg = JSON.parse(decodeBase64(parsed[key].msg));
-        });
-      }
-      return JSON.stringify(parsed, undefined, 2);
-    } catch (e) {
-      return JSON.stringify(decoded, undefined, 2);
+      return JSON.stringify(JSON.parse(decoded.toString(), reviver), null, 2);
+    } catch (_) {
+      return decoded;
     }
   }
   return JSON.stringify(str, undefined, 2);

--- a/src/components/WasmMsg.tsx
+++ b/src/components/WasmMsg.tsx
@@ -16,7 +16,6 @@ const prettifyWasmMsg = (str: string | object) => {
     try {
       return JSON.stringify(JSON.parse(decoded.toString(), reviver), null, 2);
     } catch (_) {
-      console.log(_);
       return decoded;
     }
   }

--- a/src/components/WasmMsg.tsx
+++ b/src/components/WasmMsg.tsx
@@ -1,12 +1,9 @@
 import isBase64 from "is-base64";
 import { decodeBase64 } from "../scripts/utility";
 
-// is-base64 takes terra1 address as base64 as well; prevent this.
 const isBase64Extended = (value: string) =>
   typeof value === "string" &&
-  // case: terra1... address is bech32 and it naturally is base64-eligible.
-  !value.startsWith("terra1") &&
-  // case: we are only interested in json-alike base64's, which generally start with "ey" ('{')
+  // we are only interested in json-alike base64's, which generally start with "ey" ('{')
   value.startsWith("ey") &&
   // other checks
   isBase64(value);

--- a/src/components/WasmMsg.tsx
+++ b/src/components/WasmMsg.tsx
@@ -1,6 +1,7 @@
 import isBase64 from "is-base64";
 import { decodeBase64 } from "../scripts/utility";
 
+// is-base64 takes terra1 address as base64 as well; prevent this.
 const isBase64Extended = (value: string) =>
   typeof value === "string" && !value.startsWith("terra1") && isBase64(value);
 


### PR DESCRIPTION
several code fixes for wasm msg prettifier:

- use `JSON.parse`'s reviver to recursively search all inlined base64
- extend `is-base64` library for the correct usage; in this code we are only interested in JSON-alike base64, which starts with `ey`. For a malformed base64 where it DOES start with `ey` but it isn't a properly formatted JSON after deserialization, it'll fallback to catch clause.