### PR TITLE
chore: type correction, cleanup

### DIFF
--- a/src/components/WasmMsg.tsx
+++ b/src/components/WasmMsg.tsx
@@ -2,7 +2,6 @@ import isBase64 from "is-base64";
 import { decodeBase64 } from "../scripts/utility";
 
 const isBase64Extended = (value: string) =>
-  typeof value === "string" &&
   // we are only interested in json-alike base64's, which generally start with "ey" ('{')
   value.startsWith("ey") &&
   // other checks
@@ -16,7 +15,7 @@ const prettifyWasmMsg = (str: string | object) => {
     const decoded = decodeBase64(str);
     try {
       return JSON.stringify(JSON.parse(decoded, reviver), null, 2);
-    } catch (_) {
+    } catch {
       return decoded;
     }
   }

--- a/src/components/WasmMsg.tsx
+++ b/src/components/WasmMsg.tsx
@@ -8,7 +8,9 @@ const isBase64Extended = (value: string) =>
   isBase64(value);
 
 const reviver = (_: string, value: any) =>
-  isBase64Extended(value) ? JSON.parse(decodeBase64(value), reviver) : value;
+  typeof value === "string" && isBase64Extended(value)
+    ? JSON.parse(decodeBase64(value), reviver)
+    : value;
 
 const prettifyWasmMsg = (str: string | object) => {
   if (typeof str === "string" && isBase64Extended(str)) {


### PR DESCRIPTION
- this PR includes cleanup code and type correction for `isBase64Extended` -- the value `str` is always string so there is no point in checking the type of `str`