### PR TITLE
Add a way to define an environment variable to select a default network 

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
-HOST=local.terra.money
-HTTPS=true
+HOST=localhost
+HTTPS=false
 BROWSER=none
+REACT_APP_DEFAULT_NETWORK=localterra

--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ The Finder is derived from the [Cosmos Explorer](https://github.com/cosmos/explo
 npm install
 ```
 
+### Configure the environement variables
+
+If required, edit `.env.development`.
+For local development you might want to use this configuration:
+
+```
+HOST=localhost
+HTTPS=false
+BROWSER=none
+REACT_APP_DEFAULT_NETWORK=localterra
+```
+
+`REACT_APP_DEFAULT_NETWORK` is the default selected network that finder will use.
+See `src/config/networks.ts` for the list of available networks.
+
+
 ### Compiles and hot-reloads for development
 ```
 npm start

--- a/src/scripts/utility.ts
+++ b/src/scripts/utility.ts
@@ -7,7 +7,10 @@ import networksConfig from "../config/networks";
 import { isInteger } from "./math";
 import { filter } from "lodash";
 
-export const DEFAULT_NETWORK = networksConfig[0].key || "columbus-4";
+export const DEFAULT_NETWORK =
+  process.env.REACT_APP_DEFAULT_NETWORK ||
+  networksConfig[0].key ||
+  "columbus-4";
 export const DEFAULT_CURRENCY = `uusd`;
 export const DEFAULT_FCD = `https://fcd.terra.dev`;
 export const DEFAULT_MANTLE = "https://mantle.terra.dev";


### PR DESCRIPTION
When developing, I find it practical to have localterra as the default network.

This is also part of an idea I had to include finder as part of terra-money/localterra docker-compose and define REACT_APP_DEFAULT_NETWORK as localterra so it's already there and ready use as part of an dev env setup.