### PR TITLE
Feature/recover tax rate final

### DIFF
--- a/src/contexts/ChainsContext.ts
+++ b/src/contexts/ChainsContext.ts
@@ -15,7 +15,7 @@ const useNetworkFromRouteMatch = () => {
 };
 
 export const useCurrentChain = () => {
-  const chains = useChains();
+  const chains:ChainOption[] = useChains();
   const network = useNetworkFromRouteMatch();
 
   const chain =

--- a/src/pages/Account/Txs.tsx
+++ b/src/pages/Account/Txs.tsx
@@ -128,7 +128,7 @@ const Txs = ({ address }: { address: string }) => {
     `Amount (In)`,
     `Timestamp`,
     `Fee`,
-    isClassic ? "Burn Tax" : ""
+    isClassic ? "Tax" : ""
   ];
 
   return (

--- a/src/pages/Account/Txs.tsx
+++ b/src/pages/Account/Txs.tsx
@@ -18,7 +18,8 @@ import { useCurrentChain, useIsClassic } from "../../contexts/ChainsContext";
 import {
   fromISOTime,
   sliceMsgType,
-  splitCoinData
+  splitCoinData,
+  getTaxData
 } from "../../scripts/utility";
 import format from "../../scripts/format";
 import { useLogfinderAmountRuleSet } from "../../hooks/useLogfinder";
@@ -182,11 +183,8 @@ const getRow = (
   const [amountIn, amountOut] = getAmount(address, matchedMsg, 3);
   const fee = getTxFee(txBody?.value?.fee?.amount?.[0], isClassic);
   const feeData = fee?.split(" ");
-  const tax =
-    splitCoinData(
-      get(logs, "[1].log.tax") || (get(logs, "[0].log.tax") as string)
-    ) || "0";
-
+  const tax = get(logs, "[1].log.tax") || get(logs, "[0].log.tax");
+  const taxData = getTaxData(tax);
   return [
     <span>
       <div className={s.wrapper}>
@@ -238,9 +236,9 @@ const getRow = (
       />
     </span>,
     <span className={s.amount}>
-      {tax !== "0" ? (
+      {taxData ? (
         <span>
-          <Coin amount={tax.amount} denom={tax.denom} />
+          <Coin amount={taxData.amount} denom={taxData.denom} />
         </span>
       ) : (
         ""

--- a/src/pages/Account/Txs.tsx
+++ b/src/pages/Account/Txs.tsx
@@ -236,7 +236,7 @@ const getRow = (
       />
     </span>,
     <span className={s.amount}>
-      {taxData ? (
+      {taxData && isClassic ? (
         <span>
           <Coin amount={taxData.amount} denom={taxData.denom} />
         </span>

--- a/src/pages/Account/Txs.tsx
+++ b/src/pages/Account/Txs.tsx
@@ -53,7 +53,7 @@ const getRenderAmount = (
   });
 };
 
-export const getAmount = (
+const getAmount = (
   address: string,
   matchedMsg?: LogFinderAmountResult[][],
   rowLimit?: number

--- a/src/pages/Account/Txs.tsx
+++ b/src/pages/Account/Txs.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { get, isEmpty } from "lodash";
+import { isEmpty } from "lodash";
 import {
   LogFinderAmountResult,
   getTxAmounts,
@@ -19,7 +19,6 @@ import {
   fromISOTime,
   sliceMsgType,
   splitCoinData,
-  getTaxData
 } from "../../scripts/utility";
 import format from "../../scripts/format";
 import { useLogfinderAmountRuleSet } from "../../hooks/useLogfinder";
@@ -27,6 +26,7 @@ import useRequest from "../../hooks/useRequest";
 import { useGetQueryURL } from "../../queries/query";
 import TxAmount from "../Tx/TxAmount";
 import { transformTx } from "../Tx/transform";
+import TaxRateAmount from "../Tx/TaxRateAmount";
 import CsvExport from "./CSVExport";
 import s from "./Txs.module.scss";
 
@@ -129,7 +129,7 @@ const Txs = ({ address }: { address: string }) => {
     `Amount (In)`,
     `Timestamp`,
     `Fee`,
-    isClassic ? "Tax" : ""
+    isClassic ? "Tax" : null
   ];
 
   return (
@@ -183,8 +183,7 @@ const getRow = (
   const [amountIn, amountOut] = getAmount(address, matchedMsg, 3);
   const fee = getTxFee(txBody?.value?.fee?.amount?.[0], isClassic);
   const feeData = fee?.split(" ");
-  const tax = get(logs, "[1].log.tax") || get(logs, "[0].log.tax");
-  const taxData = getTaxData(tax);
+
   return [
     <span>
       <div className={s.wrapper}>
@@ -235,14 +234,8 @@ const getRow = (
         isFormatAmount={true}
       />
     </span>,
-    <span className={s.amount}>
-      {taxData && isClassic ? (
-        <span>
-          <Coin amount={taxData.amount} denom={taxData.denom} />
-        </span>
-      ) : (
-        ""
-      )}
+    <span>
+      <TaxRateAmount logs={logs} />
     </span>
   ];
 };

--- a/src/pages/Tx/TaxRateAmount.tsx
+++ b/src/pages/Tx/TaxRateAmount.tsx
@@ -1,0 +1,31 @@
+import { useIsClassic } from "../../contexts/ChainsContext";
+import format from "../../scripts/format";
+import { getTaxData } from "../../scripts/utility";
+import { get } from "lodash";
+
+interface Props {
+  logs: Log[] | undefined
+}
+
+const TaxRateAmount = ({ logs }: Props) => {
+  const isClassic = useIsClassic();
+
+  if(!isClassic){
+    return <></>;
+  }
+
+  const tax = get(logs, "[0].log.tax") || get(logs, "[1].log.tax") || "",
+    { denom, amount } = getTaxData(tax) || {};
+
+  if (!denom || !amount) {
+    return <>-</>;
+  }
+
+  return (
+    <>
+      {format.amount(amount)} {format.denom(denom, isClassic)}
+    </>
+  );
+};
+
+export default TaxRateAmount;

--- a/src/pages/Tx/TaxRateAmount.tsx
+++ b/src/pages/Tx/TaxRateAmount.tsx
@@ -1,16 +1,16 @@
 import { useIsClassic } from "../../contexts/ChainsContext";
-import format from "../../scripts/format";
 import { getTaxData } from "../../scripts/utility";
 import { get } from "lodash";
+import Amount from "../../components/Amount";
 
 interface Props {
-  logs: Log[] | undefined
+  logs: Log[] | undefined;
 }
 
 const TaxRateAmount = ({ logs }: Props) => {
   const isClassic = useIsClassic();
 
-  if(!isClassic){
+  if (!isClassic) {
     return <></>;
   }
 
@@ -21,11 +21,7 @@ const TaxRateAmount = ({ logs }: Props) => {
     return <>-</>;
   }
 
-  return (
-    <>
-      {format.amount(amount)} {format.denom(denom, isClassic)}
-    </>
-  );
+  return <Amount denom={denom}>{amount}</Amount>;
 };
 
 export default TaxRateAmount;

--- a/src/pages/Tx/Tx.tsx
+++ b/src/pages/Tx/Tx.tsx
@@ -24,7 +24,7 @@ import TxAmount from "./TxAmount";
 import { transformTx } from "./transform";
 import s from "./Tx.module.scss";
 import { useIsClassic } from "../../contexts/ChainsContext";
-import { splitCoinData } from "../../scripts/utility";
+import { getTaxData } from "../../scripts/utility";
 import Coin from "../../components/Coin";
 
 const TxComponent = ({ hash }: { hash: string }) => {
@@ -47,11 +47,8 @@ const TxComponent = ({ hash }: { hash: string }) => {
   const matchedMsg = getTxAllCanonicalMsgs(JSON.stringify(tx), logMatcher);
 
   const fee: Amount[] = get(tx, "tx.value.fee.amount");
-  const tax = isClassic
-    ? splitCoinData(
-        get(tx, "logs[1].log.tax") || (get(tx, "logs[0].log.tax") as string)
-      ) || "0"
-    : "0";
+  const tax = get(tx, "logs[1].log.tax") || get(tx, "logs[0].log.tax");
+  const taxData = getTaxData(tax);
 
   // status settings
   const status = isPending ? (
@@ -130,11 +127,11 @@ const TxComponent = ({ hash }: { hash: string }) => {
           <></>
         )}
 
-        {isClassic && tax !== "0" ? (
+        {isClassic && taxData ? (
           <div className={s.row}>
             <div className={s.head}>Tax</div>
             <div className={s.body}>
-              <Coin amount={tax.amount} denom={tax.denom} />
+              <Coin amount={taxData.amount} denom={taxData.denom} />
             </div>
           </div>
         ) : (

--- a/src/pages/Tx/Tx.tsx
+++ b/src/pages/Tx/Tx.tsx
@@ -132,7 +132,7 @@ const TxComponent = ({ hash }: { hash: string }) => {
 
         {isClassic && tax !== "0" ? (
           <div className={s.row}>
-            <div className={s.head}>Burn Tax</div>
+            <div className={s.head}>Tax</div>
             <div className={s.body}>
               <Coin amount={tax.amount} denom={tax.denom} />
             </div>

--- a/src/pages/Tx/Tx.tsx
+++ b/src/pages/Tx/Tx.tsx
@@ -47,10 +47,11 @@ const TxComponent = ({ hash }: { hash: string }) => {
   const matchedMsg = getTxAllCanonicalMsgs(JSON.stringify(tx), logMatcher);
 
   const fee: Amount[] = get(tx, "tx.value.fee.amount");
-  const tax =
-    splitCoinData(
-      get(tx, "logs[1].log.tax") || (get(tx, "logs[0].log.tax") as string)
-    ) || "0";
+  const tax = isClassic
+    ? splitCoinData(
+        get(tx, "logs[1].log.tax") || (get(tx, "logs[0].log.tax") as string)
+      ) || "0"
+    : "0";
 
   // status settings
   const status = isPending ? (

--- a/src/pages/Tx/Tx.tsx
+++ b/src/pages/Tx/Tx.tsx
@@ -21,11 +21,10 @@ import format from "../../scripts/format";
 import Pending from "./Pending";
 import Searching from "./Searching";
 import TxAmount from "./TxAmount";
+import TaxRateAmount from "./TaxRateAmount";
 import { transformTx } from "./transform";
 import s from "./Tx.module.scss";
 import { useIsClassic } from "../../contexts/ChainsContext";
-import { getTaxData } from "../../scripts/utility";
-import Coin from "../../components/Coin";
 
 const TxComponent = ({ hash }: { hash: string }) => {
   const ruleSet = useLogfinderActionRuleSet();
@@ -47,8 +46,6 @@ const TxComponent = ({ hash }: { hash: string }) => {
   const matchedMsg = getTxAllCanonicalMsgs(JSON.stringify(tx), logMatcher);
 
   const fee: Amount[] = get(tx, "tx.value.fee.amount");
-  const tax = get(tx, "logs[1].log.tax") || get(tx, "logs[0].log.tax");
-  const taxData = getTaxData(tax);
 
   // status settings
   const status = isPending ? (
@@ -127,11 +124,11 @@ const TxComponent = ({ hash }: { hash: string }) => {
           <></>
         )}
 
-        {isClassic && taxData ? (
+        {isClassic ? (
           <div className={s.row}>
             <div className={s.head}>Tax</div>
             <div className={s.body}>
-              <Coin amount={taxData.amount} denom={taxData.denom} />
+              <TaxRateAmount logs={tx.logs} />
             </div>
           </div>
         ) : (

--- a/src/pages/Txs/Txs.tsx
+++ b/src/pages/Txs/Txs.tsx
@@ -33,7 +33,11 @@ const getRow = (response: TxInfo, chainID: string, isClassic?: boolean) => {
       )}
     </span>,
     <span>
-      {taxData ? <Coin amount={taxData.amount} denom={taxData.denom} /> : ""}
+      {taxData && isClassic ? (
+        <Coin amount={taxData.amount} denom={taxData.denom} />
+      ) : (
+        ""
+      )}
     </span>,
     <span>
       <Finder q="blocks" v={String(height)}>

--- a/src/pages/Txs/Txs.tsx
+++ b/src/pages/Txs/Txs.tsx
@@ -30,9 +30,7 @@ const getRow = (response: TxInfo, chainID: string, isClassic?: boolean) => {
         <TxAmount amount={fee.amount} denom={fee.denom} />
       )}
     </span>,
-    <span>
-      <TaxRateAmount logs={logs} />
-    </span>,
+    <span>{isClassic ? <TaxRateAmount logs={logs} /> : ""}</span>,
     <span>
       <Finder q="blocks" v={String(height)}>
         {String(height)}

--- a/src/pages/Txs/Txs.tsx
+++ b/src/pages/Txs/Txs.tsx
@@ -31,11 +31,6 @@ const getRow = (response: TxInfo, chainID: string, isClassic?: boolean) => {
       )}
     </span>,
     <span>{isClassic ? <TaxRateAmount logs={logs} /> : ""}</span>,
-    <span>
-      <Finder q="blocks" v={String(height)}>
-        {String(height)}
-      </Finder>
-    </span>,
     <span>{height}</span>,
     <span>{fromNow(timestamp.toString())}</span>
   ];

--- a/src/pages/Txs/Txs.tsx
+++ b/src/pages/Txs/Txs.tsx
@@ -4,19 +4,17 @@ import FlexTable from "../../components/FlexTable";
 import Info from "../../components/Info";
 import Card from "../../components/Card";
 import Finder from "../../components/Finder";
-import { fromNow, sliceMsgType, getTaxData } from "../../scripts/utility";
+import { fromNow, sliceMsgType } from "../../scripts/utility";
 import TxAmount from "../Tx/TxAmount";
 import { transformTx } from "../Tx/transform";
 import { useCurrentChain, useIsClassic } from "../../contexts/ChainsContext";
 import s from "./Txs.module.scss";
-import Coin from "../../components/Coin";
+import TaxRateAmount from "../Tx/TaxRateAmount";
 
 const getRow = (response: TxInfo, chainID: string, isClassic?: boolean) => {
   const transformed = transformTx(response, chainID);
   const { txhash, tx, height, timestamp, logs } = transformed;
   const fee = get(tx, `value.fee.amount[0]`);
-  const tax = get(logs, "[1].log.tax") || get(logs, "[0].log.tax");
-  const taxData = getTaxData(tax);
 
   return [
     <span>
@@ -33,11 +31,7 @@ const getRow = (response: TxInfo, chainID: string, isClassic?: boolean) => {
       )}
     </span>,
     <span>
-      {taxData && isClassic ? (
-        <Coin amount={taxData.amount} denom={taxData.denom} />
-      ) : (
-        ""
-      )}
+      <TaxRateAmount logs={logs} />
     </span>,
     <span>
       <Finder q="blocks" v={String(height)}>

--- a/src/scripts/utility.ts
+++ b/src/scripts/utility.ts
@@ -160,3 +160,12 @@ export const compareIs = (k: string) => (a: string, b: string) =>
 
 export const compareIsDenomIBC = (a: string, b: string) =>
   Number(isDenomIBC(a)) - Number(isDenomIBC(b));
+
+export const getTaxData = (tax: string | undefined) => {
+  if (tax) {
+    const taxData = splitCoinData(tax);
+    return taxData;
+  } else {
+    return "";
+  }
+};

--- a/src/scripts/utility.ts
+++ b/src/scripts/utility.ts
@@ -162,10 +162,7 @@ export const compareIsDenomIBC = (a: string, b: string) =>
   Number(isDenomIBC(a)) - Number(isDenomIBC(b));
 
 export const getTaxData = (tax: string | undefined) => {
-  if (tax) {
-    const taxData = splitCoinData(tax);
-    return taxData;
-  } else {
-    return "";
-  }
+  const defaultTax = "";
+  return splitCoinData(tax || defaultTax) as CoinData;
+
 };


### PR DESCRIPTION
These changes aim to display the burn tax info as voted on Classic governance proposal 3568 in Finder views on classic network only. It uses TX logs to obtain tax data charged for any given TX and is backwards compatible with older TX data and 100% compatible with other networks.